### PR TITLE
example for card tooltip.  

### DIFF
--- a/src/components/calendarCard.jsx
+++ b/src/components/calendarCard.jsx
@@ -17,6 +17,18 @@ import { ReleaseDate } from "../utils/releasedate";
 import { checkPlaying } from "../utils/checkPlaying";
 import { checkWaitlisted } from "../utils/checkWaitlisted";
 
+const Players = ({ gameKey, players }) => {
+  if (players && players.length > 0) {
+    return (
+      <ol>
+        {players.map(player => <li key={`${gameKey}_pname_${player.discord_name}`}>{player.discord_name}</li>)}
+      </ol>
+    );
+  } else {
+    return 'None yet, sign up today!';
+  }
+}
+
 const Game = (props) => {
   const {
     module,
@@ -33,7 +45,7 @@ const Game = (props) => {
   } = props;
 
   return (
-    <Card raised="true" sx={{ maxWidth: 450 }}>
+    <Card raised={true} sx={{ maxWidth: 450 }}>
       <CardContent sx={{ pt: 0.75, pb: 0.2, "&:last-child": { pb: 0 } }}>
         <Grid
           container
@@ -82,8 +94,7 @@ const Game = (props) => {
       <CardActions sx={{ py: 0 }}>
         <Grid container direction="row" justifyContent="space-between">
           <Tooltip
-            // title={<React.Fragment>{checkPlaying(players)}</React.Fragment>}
-            title="works with text but not with fragment - I'm trying to display the list of player names (list management not yet in the line above)"
+            title={<Players gameKey={`${dm_name}_${datetime}_playing`} players={checkPlaying(players)}/>}
             placement="top-start"
           >
             <Box p={1} textAlign="center" sx={{ flexGrow: 1 }}>
@@ -96,6 +107,10 @@ const Game = (props) => {
             </Box>
           </Tooltip>
           <Divider orientation="vertical" variant="middle" flexItem />
+           <Tooltip
+            title={<Players gameKey={`${dm_name}_${datetime}_waitlisted`} players={checkWaitlisted(players)}/>}
+            placement="top-start"
+          >
           <Box p={1} textAlign="center" sx={{ flexGrow: 1 }}>
             <Typography variant="body1" color="text.primary">
               Waitlist
@@ -103,7 +118,8 @@ const Game = (props) => {
             <Typography variant="h6" color="text.primary">
               {checkWaitlisted(players).length}
             </Typography>
-          </Box>
+            </Box>
+            </Tooltip>
         </Grid>
       </CardActions>
       <CardActions sx={{ pt: 0.2 }}>

--- a/src/components/resDMbioCard.jsx
+++ b/src/components/resDMbioCard.jsx
@@ -9,7 +9,7 @@ import PlaceIcon from "@mui/icons-material/Place";
 const ResDMbio = (dm) => {
   return (
     <div className="masonry-card">
-      <Card raised="true" sx={{ maxWidth: 500 }}>
+      <Card raised={true} sx={{ maxWidth: 500 }}>
         <CardContent>
           <div alignItems="center" className="resDMbioCard">
             <div className="name">

--- a/src/pages/Calendar.jsx
+++ b/src/pages/Calendar.jsx
@@ -23,7 +23,6 @@ export default function Calendar() {
   //Only filtering for future games at present
   const filteredData = data.filter((x) => Date.parse(x.datetime) > new Date());
   const lastDate = filteredData.map((a) => a.datetime).reverse()[0];
-
   return (
     <React.Fragment>
       <Grid
@@ -66,7 +65,7 @@ export default function Calendar() {
         sx={{ px: 2, mb: 3, position: "relative" }}
       >
         {filteredData.map((gameData) => (
-          <Grid item xs={12} sm={6} md={4} lg={3}>
+          <Grid key={`${gameData.dm_name}_${gameData.datetime}`} item xs={12} sm={6} md={4} lg={3}>
             <Game {...gameData} />
           </Grid>
         ))}


### PR DESCRIPTION
quick approach, a separate <Players/> function to create an ordered list in the tooltip. Also cleaned up a couple prop errors.