### PR TITLE
localize at least en and en-GB on date forms

### DIFF
--- a/src/components/game/DateTimeSelector.jsx
+++ b/src/components/game/DateTimeSelector.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { DateTimePicker } from "@mui/x-date-pickers";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { AdapterMoment } from "@mui/x-date-pickers/AdapterMoment";
@@ -7,9 +7,6 @@ import moment from "moment/min/moment-with-locales";
 
 export default function DateTimeSelector(props) {
   const { values, errors, setFieldValue } = useFormikContext();
-  useEffect(() => {
-    
-  }, [navigator.language])
   const mValue = useMemo(() => {
     if (values[props.name]) {
       if (navigator?.language.indexOf('en-GB') > -1) {

--- a/src/components/game/DateTimeSelector.jsx
+++ b/src/components/game/DateTimeSelector.jsx
@@ -1,19 +1,32 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { DateTimePicker } from "@mui/x-date-pickers";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { AdapterMoment } from "@mui/x-date-pickers/AdapterMoment";
 import { useFormikContext } from "formik";
-import moment from "moment";
+import moment from "moment/min/moment-with-locales";
 
 export default function DateTimeSelector(props) {
   const { values, errors, setFieldValue } = useFormikContext();
-
+  useEffect(() => {
+    
+  }, [navigator.language])
   const mValue = useMemo(() => {
-    return moment(values[props.name]);
-  }, [values[props.name]]);
+    if (values[props.name]) {
+      if (navigator?.language.indexOf('en-GB') > -1) {
+        moment.locale('en-GB');
+      } else {
+        moment.locale('en');
+      }
+      return moment(values[props.name]);
+    } else {
+      return undefined;
+    }
+  }, [values[props.name], navigator]);
+
+  console.info(moment.localeData().longDateFormat('L'))
   const error = errors?.[props.name];
   return (
-    <LocalizationProvider dateAdapter={AdapterMoment}>
+    <LocalizationProvider dateAdapter={AdapterMoment} dateFormats={"YYYY"}>
       <DateTimePicker
         label={props.label}
         value={mValue}
@@ -22,6 +35,7 @@ export default function DateTimeSelector(props) {
           setFieldValue(props.name, val.toDate());
           props?.onChange(val.toDate());
         }}
+        format={`${moment.localeData().longDateFormat('L')} HH:MM`}
         shouldDisableDate={(val) => {
           return !!error ? val.toDate().getTime() === mValue.toDate().getTime() : false;
         }}


### PR DESCRIPTION
let people see the datetime inthe format they want, regardless of the shape they think of when they hear the word football.  (English US and English GB only at this time.)