### PR TITLE
change locale (dayjs version) to adapterLocale (date-fns version)

### DIFF
--- a/src/components/game/DateTimeSelector.jsx
+++ b/src/components/game/DateTimeSelector.jsx
@@ -1,26 +1,26 @@
 import { useMemo } from "react";
 import { DateTimePicker } from "@mui/x-date-pickers";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV3'
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFnsV3";
 import { useFormikContext } from "formik";
 import { enGB, enUS } from "date-fns/locale";
 
 export default function DateTimeSelector(props) {
   const { values, errors, setFieldValue } = useFormikContext();
-   const locale = useMemo(() => {
+  const locale = useMemo(() => {
     if (navigator?.language.indexOf("en-GB") > -1) {
       return enGB;
     } else {
       return enUS;
     }
-  }, [ navigator])
+  }, [navigator]);
   const mValue = useMemo(() => {
-      return values[props.name];
+    return values[props.name];
   }, [values[props.name]]);
 
   const error = errors?.[props.name];
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns} locale={locale} dateFormats={"YYYY"}>
+    <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={locale} dateFormats={"YYYY"}>
       <DateTimePicker
         disabled={props.disabled}
         sx={props.sx}


### PR DESCRIPTION
MUI's localizationprovider uses different argument names (locale vs adapaterLocale) for different providers.  When we changed from dayjs to date-fns, this needed to change too.  Browsers with en-GB as their preferred language will see dd/mmy/yyyy, and otherwise will see mm/dd/yyyy