### PR TITLE
add day filter

### DIFF
--- a/src/api/games.js
+++ b/src/api/games.js
@@ -79,12 +79,14 @@ export function useGames() {
 
       const data = rsp.data
         .map((game) => {
+          const dt = new Date(game.datetime);
           return {
             ...game,
             datetime: new Date(game.datetime),
             players: game.players,
             standby: game.waitlist,
-            slot: Math.floor(new Date(game.datetime).getHours() / 4),
+            day: dt.getDay(),
+            slot: Math.floor(dt.getHours() / 4),
             datetime_open_release: game.datetime_open_release === null ? null : new Date(game.datetime_open_release),
             datetime_release: game.datetime_release === null ? null : new Date(game.datetime_release),
           };

--- a/src/components/Filters.jsx
+++ b/src/components/Filters.jsx
@@ -4,13 +4,11 @@ import {
   Autocomplete,
   Box,
   Button,
-  Checkbox,
   Drawer,
   FormControl,
   RadioGroup,
   Radio,
   FormControlLabel,
-  FormHelperText,
   FormLabel,
   TextField,
   Typography,
@@ -43,6 +41,7 @@ function Filters() {
   const user = useUserStore((s) => s.user);
   const [
     allTimeSlots,
+    allDays,
     allRealms,
     allVariants,
     allTiers,
@@ -50,6 +49,8 @@ function Filters() {
     setName,
     slots,
     setSlots,
+    days,
+    setDays,
     realms,
     setRealms,
     variants,
@@ -62,6 +63,7 @@ function Filters() {
     setStreaming,
   ] = useFilterStore((s) => [
     s.allTimeSlots,
+    s.allDays,
     s.allRealms,
     s.allVariants,
     s.allTiers,
@@ -69,6 +71,8 @@ function Filters() {
     s.setName,
     s.slots,
     s.setSlots,
+    s.days,
+    s.setDays,
     s.realms,
     s.setRealms,
     s.variants,
@@ -84,6 +88,9 @@ function Filters() {
     return sName || "";
   }, [sName]);
 
+  const dayStrings = useMemo(() => {
+    return (allDays || []).map((slot) => slot.text);
+  }, [allDays]);
   const timeStrings = useMemo(() => {
     return (allTimeSlots || []).map((slot) => slot.text);
   }, [allTimeSlots]);
@@ -91,6 +98,14 @@ function Filters() {
     const fs = [];
     if (name?.length) {
       fs.push(`Name: ${name}`);
+    }
+    if (days?.length) {
+      fs.push(
+        `Days: ${days
+          .sort()
+          .map((day) => dayStrings[day])
+          .join(", ")}`,
+      );
     }
     if (slots?.length) {
       fs.push(
@@ -120,7 +135,15 @@ function Filters() {
       filterString: fs.join(", "),
       filterCount: fs.length,
     };
-  }, [name, slots, realms, variants, tiers, playTest, streaming]);
+  }, [name, days, slots, realms, variants, tiers, playTest, streaming]);
+
+  const dayVals = useMemo(() => {
+    return allDays.filter((day) => days.includes(day.value));
+  }, [allDays, days]);
+
+  const timeSlotVals = useMemo(() => {
+    return allTimeSlots.filter((slot) => slots.includes(slot.value));
+  }, [allTimeSlots, slots]);
 
   const realmVals = useMemo(() => {
     if (realms?.length) {
@@ -165,6 +188,7 @@ function Filters() {
               variant="contained"
               onClick={() => {
                 setName("");
+                setDays([]);
                 setSlots([]);
                 setRealms([]);
                 setVariants([]);
@@ -227,26 +251,26 @@ function Filters() {
             value={name}
             onChange={(evt) => setName(evt.target.value)}
           />
-          <Box sx={{ width: "100%", display: "grid", gridTemplateColumns: "50% 50%" }}>
-            {allTimeSlots.map((slot) => (
-              <FormControlLabel
-                key={`${slot.value}_${slot.text}`}
-                checked={slots.some((s) => s === slot.value)}
-                control={
-                  <Checkbox
-                    onChange={(evt) => {
-                      if (evt.target.checked) {
-                        setSlots([...slots, slot.value]);
-                      } else {
-                        setSlots(slots.filter((s) => s !== slot.value));
-                      }
-                    }}
-                  />
-                }
-                label={<FormHelperText>{slot.text}</FormHelperText>}
-              />
-            ))}
-          </Box>
+          <Autocomplete
+            multiple
+            id="combo-box-days"
+            options={allDays}
+            getOptionLabel={(slot) => slot.text}
+            getOptionKey={(slot) => slot.value}
+            value={dayVals}
+            onChange={(evt, value) => setDays(value.map((val) => val.value))}
+            renderInput={(params) => <TextField {...params} label="Days" />}
+          />
+          <Autocomplete
+            multiple
+            id="combo-box-slots"
+            options={allTimeSlots}
+            getOptionLabel={(slot) => slot.text}
+            getOptionKey={(slot) => slot.value}
+            value={timeSlotVals}
+            onChange={(evt, value) => setSlots(value.map((val) => val.value))}
+            renderInput={(params) => <TextField {...params} label="Time Slots" />}
+          />
           <Autocomplete
             multiple
             id="combo-box-realms"

--- a/src/pages/Calendar.jsx
+++ b/src/pages/Calendar.jsx
@@ -41,8 +41,8 @@ function DiscordButton({ children }) {
 
 export default function Calendar() {
   const user = useUserStore((s) => s.user);
-  const [name, slots, realms, filter, variants, tiers, playTest, streaming] = useFilterStore(
-    useShallow((s) => [s.name, s.slots, s.realms, s.filter, s.variants, s.tiers, s.playTest, s.streaming]),
+  const [name, days, slots, realms, filter, variants, tiers, playTest, streaming] = useFilterStore(
+    useShallow((s) => [s.name, s.days, s.slots, s.realms, s.filter, s.variants, s.tiers, s.playTest, s.streaming]),
   );
 
   const { data, isLoading, joinGame, dropGame } = useGames();
@@ -64,7 +64,7 @@ export default function Calendar() {
       ];
     }
     return filter(data);
-  }, [isLoading, data, filter, name, slots, realms, variants, tiers, user, playTest, streaming]);
+  }, [isLoading, data, filter, name, days, slots, realms, variants, tiers, user, playTest, streaming]);
 
   const lastDate = useMemo(() => {
     return data?.map((a) => a.datetime).reverse()[0] || new Date();

--- a/src/stores/useFilterStore.js
+++ b/src/stores/useFilterStore.js
@@ -32,6 +32,16 @@ const timeSlots = [
   { value: 5, text: "8PM-Midnight" },
 ];
 
+const days = [
+  { value: 0, text: "Sunday" },
+  { value: 1, text: "Monday" },
+  { value: 2, text: "Tuesday" },
+  { value: 3, text: "Wednesday" },
+  { value: 4, text: "Thursday" },
+  { value: 5, text: "Friday" },
+  { value: 6, text: "Saturday" },
+];
+
 const tiers = [
   { value: 1, text: "1" },
   { value: 2, text: "2" },
@@ -65,6 +75,10 @@ function slotFilterFn(gameData, slots) {
   return slots.length === 0 || slots.some((s) => s === gameData.slot);
 }
 
+function dayFilterFn(gameData, days) {
+  return days.length === 0 || days.some((s) => s === gameData.day);
+}
+
 function nameFilterFn(gameData, activeName) {
   return activeName
     ? (gameData.players &&
@@ -85,8 +99,15 @@ function nameFilterFn(gameData, activeName) {
     : true;
 }
 
-function filterGames(data, activeName, slot, realms, variants, tiers, playTests, streaming) {
-  if (slot?.length > 0 || activeName?.length > 0 || realms?.length > 0 || variants?.length > 0 || tiers?.length > 0) {
+function filterGames(data, activeName, day, slot, realms, variants, tiers, playTests, streaming) {
+  if (
+    day?.length > 0 ||
+    slot?.length > 0 ||
+    activeName?.length > 0 ||
+    realms?.length > 0 ||
+    variants?.length > 0 ||
+    tiers?.length > 0
+  ) {
     //tier fn is odd, becuse we have games that can span ranges, and people can seelct multiple different tiers
     //would be nice to have a jest test setup, but logic is if:
     // 1) game min >= tier min AND
@@ -106,6 +127,7 @@ function filterGames(data, activeName, slot, realms, variants, tiers, playTests,
     return data.filter((gameData) => {
       return (
         slotFilterFn(gameData, slot) &&
+        dayFilterFn(gameData, day) &&
         nameFilterFn(gameData, activeName) &&
         realmFilterFn(gameData, realms) &&
         variantFilterFn(gameData, variants) &&
@@ -128,6 +150,9 @@ const useFilterStore = create(
       allTimeSlots: timeSlots,
       slots: [],
       setSlots: (sl) => set({ slots: sl }),
+      allDays: days,
+      days: [],
+      setDays: (dys) => set({ days: dys }),
       name: undefined,
       setName: (nm) => set({ name: nm }),
       allVariants: variants,
@@ -141,7 +166,17 @@ const useFilterStore = create(
       streaming: undefined,
       setStreaming: (st) => set({ streaming: st === "" || st === undefined ? undefined : st === "true" }),
       filter: (games) =>
-        filterGames(games, get().name, get().slots, get().realms, get().variants, get().tiers, get().playTest, get().streaming),
+        filterGames(
+          games,
+          get().name,
+          get().days,
+          get().slots,
+          get().realms,
+          get().variants,
+          get().tiers,
+          get().playTest,
+          get().streaming,
+        ),
     }),
     {
       name: SHOW_KEY_PREFIX,


### PR DESCRIPTION
went with separating day and time into separate autocomplete boxes and independent parameters, such that the screen shot would find all games Tuesday and Thursday that start in those two time slots. 

<img width="869" alt="image" src="https://github.com/user-attachments/assets/7feb1f46-f5d3-4321-a072-eded30d7246a">

Other approach would be to combine day and time, so that you would have to select Tuesday 8AM-Noon, Tuesday Noon-4PM, Thursday 8AM-Noon, Thursday Noon-4PM -- which would allow for more precise selections but seems more cumbersome.